### PR TITLE
Mark a paper "SelfDefend" with "USENIX Security'25"

### DIFF
--- a/collection/paper/safety/jailbreak.md
+++ b/collection/paper/safety/jailbreak.md
@@ -182,7 +182,7 @@
 - [2024/06] **[MLLMGuard: A Multi-dimensional Safety Evaluation Suite for Multimodal Large Language Models](https://arxiv.org/abs/2406.07594)** ![VLM](https://img.shields.io/badge/VLM-c7688b)
 - [2024/06] **[Merging Improves Self-Critique Against Jailbreak Attacks](https://arxiv.org/abs/2406.07188)** ![LLM](https://img.shields.io/badge/LLM-589cf4)
 - [2024/06] **[How Alignment and Jailbreak Work: Explain LLM Safety through Intermediate Hidden States](https://arxiv.org/abs/2406.05644)** ![LLM](https://img.shields.io/badge/LLM-589cf4)
-- [2024/06] **[SelfDefend: LLMs Can Defend Themselves against Jailbreaking in a Practical Manner](https://arxiv.org/abs/2406.05498)** ![LLM](https://img.shields.io/badge/LLM-589cf4) ![Defense](https://img.shields.io/badge/Defense-87b800)
+- [2024/06] **[SelfDefend: LLMs Can Defend Themselves against Jailbreaking in a Practical Manner](https://arxiv.org/abs/2406.05498)** ![LLM](https://img.shields.io/badge/LLM-589cf4) ![Defense](https://img.shields.io/badge/Defense-87b800) ![USENIX_Security'25](https://img.shields.io/badge/USENIX_Security'25-f1b800)
 - [2024/06] **[Unveiling the Safety of GPT-4o: An Empirical Study using Jailbreak Attacks](https://arxiv.org/abs/2406.06302)** ![VLM](https://img.shields.io/badge/VLM-c7688b)
 - [2024/06] **[Adversarial Tuning: Defending Against Jailbreak Attacks for LLMs](https://arxiv.org/pdf/2406.06622)** ![LLM](https://img.shields.io/badge/LLM-589cf4) ![Defense](https://img.shields.io/badge/Defense-87b800)
 - [2024/06] **[Improving Alignment and Robustness with Short Circuiting](https://arxiv.org/abs/2406.04313)** ![LLM](https://img.shields.io/badge/LLM-589cf4) ![Defense](https://img.shields.io/badge/Defense-87b800)


### PR DESCRIPTION
Because the paper "SelfDefend: LLMs Can Defend Themselves against Jailbreaking in a Practical Manner" has been accepted by USENIX Security 2025, I mark this paper with "USENIX Security'25".