### PR TITLE
Add CircleGuardBenchmark and leaderboard

### DIFF
--- a/collection/leaderboard.md
+++ b/collection/leaderboard.md
@@ -1,4 +1,5 @@
 # Leaderboard
+- [2025/05] **[CircleGuardBench Leaderboard](https://huggingface.co/spaces/whitecircle-ai/circle-guard-bench)**
 - [2024/02] **[Red-Teaming Resistance Leaderboard](https://huggingface.co/blog/leaderboards-on-the-hub-haizelab)**
 - [2024/01] **[LLM Safety Leaderboard](https://huggingface.co/spaces/AI-Secure/llm-trustworthy-leaderboard)**
 - [2024/01] **[Hallucinations Leaderboard](https://huggingface.co/spaces/hallucinations-leaderboard/leaderboard)**

--- a/collection/paper/safety/general.md
+++ b/collection/paper/safety/general.md
@@ -1,4 +1,5 @@
 # A0. General
+- [2025/05] **[CircleGuardBench - A full-fledged benchmark for evaluating protection capabilities of AI models](https://huggingface.co/blog/whitecircle-ai/circleguardbench)** ![LLM](https://img.shields.io/badge/LLM-589cf4) ![benchmark](https://img.shields.io/badge/benchmark-87b800)
 - [2025/04] **[𝚂𝙰𝙶𝙴: A Generic Framework for LLM Safety Evaluation](https://arxiv.org/abs/2504.19674)** ![LLM](https://img.shields.io/badge/LLM-589cf4)
 - [2025/03] **[MMDT: Decoding the Trustworthiness and Safety of Multimodal Foundation Models](https://arxiv.org/abs/2503.14827)** ![VLM](https://img.shields.io/badge/VLM-c7688b) ![benchmark](https://img.shields.io/badge/benchmark-87b800) ![ICLR'25](https://img.shields.io/badge/ICLR'25-f1b800)
 - [2025/03] **[LLM-Safety Evaluations Lack Robustness](https://arxiv.org/abs/2503.02574)** ![LLM](https://img.shields.io/badge/LLM-589cf4)


### PR DESCRIPTION
Hi!
I’d be glad if you could take a look at the following work and consider adding it to the relevant sections:

**CircleGuardBench – A full-fledged benchmark for evaluating protection capabilities of AI models**
• Repository: https://github.com/whitecircle-ai/circle-guard-bench
• Blog post explaining the methodology: https://huggingface.co/blog/whitecircle-ai/circleguardbench
• Hugging Face Leaderboard: https://huggingface.co/spaces/whitecircle-ai/circle-guard-bench
• Dataset: https://huggingface.co/datasets/whitecircle-ai/circleguardbench_public