### PR TITLE
Add paper on universal magic word attacks against embedding-based safeguards

### DIFF
--- a/collection/paper/safety/jailbreak.md
+++ b/collection/paper/safety/jailbreak.md
@@ -231,6 +231,7 @@
 - [2025/01] **[Graph of Attacks with Pruning: Optimizing Stealthy Jailbreak Prompt Generation for Enhanced LLM Content Moderation](https://arxiv.org/abs/2501.18638)** ![LLM](https://img.shields.io/badge/LLM-589cf4)
 - [2025/01] **[Enhancing Model Defense Against Jailbreaks with Proactive Safety Reasoning](https://arxiv.org/abs/2501.19180)** ![LLM](https://img.shields.io/badge/LLM-589cf4) ![Defense](https://img.shields.io/badge/Defense-87b800)
 - [2025/01] **[GuardReasoner: Towards Reasoning-based LLM Safeguards](https://arxiv.org/abs/2501.18492)** ![LLM](https://img.shields.io/badge/LLM-589cf4) ![Defense](https://img.shields.io/badge/Defense-87b800)
+- [2025/01] **[Jailbreaking LLMs' Safeguard with Universal Magic Words for Text Embedding Models](https://arxiv.org/abs/2501.18280)** ![LLM](https://img.shields.io/badge/LLM-589cf4)
 - [2025/01] **[Siren: A Learning-Based Multi-Turn Attack Framework for Simulating Real-World Human Jailbreak Behaviors](https://arxiv.org/abs/2501.14250)** ![LLM](https://img.shields.io/badge/LLM-589cf4)
 - [2025/01] **[Refining Input Guardrails: Enhancing LLM-as-a-Judge Efficiency Through Chain-of-Thought Fine-Tuning and Alignment](https://arxiv.org/abs/2501.13080)** ![LLM](https://img.shields.io/badge/LLM-589cf4) ![Defense](https://img.shields.io/badge/Defense-87b800)
 - [2025/01] **[Jailbreaking Large Language Models in Infinitely Many Ways](https://arxiv.org/abs/2501.10800)** ![LLM](https://img.shields.io/badge/LLM-589cf4)


### PR DESCRIPTION
Adds arXiv 2501.18280 to the jailbreak section. The paper finds that text embedding models have a severely biased output distribution, and exploits this to craft universal suffixes that bypass embedding-based LLM safeguards across models and languages.