### PR TITLE
Add SABER jailbreak paper

### DIFF
--- a/collection/paper/safety/jailbreak.md
+++ b/collection/paper/safety/jailbreak.md
@@ -56,6 +56,7 @@
 - [2025/09] **[Jailbreaking Large Language Models Through Content Concretization](https://arxiv.org/abs/2509.12937)** ![LLM](https://img.shields.io/badge/LLM-589cf4)
 - [2025/09] **[A Simple and Efficient Jailbreak Method Exploiting LLMs' Helpfulness](https://arxiv.org/abs/2509.14297)** ![LLM](https://img.shields.io/badge/LLM-589cf4)
 - [2025/09] **[LLM Jailbreak Detection for (Almost) Free!](https://arxiv.org/abs/2509.14558)** ![LLM](https://img.shields.io/badge/LLM-589cf4)
+- [2025/09] **[SABER: Uncovering Vulnerabilities in Safety Alignment via Cross-Layer Residual Connection](https://arxiv.org/abs/2509.16060)** ![LLM](https://img.shields.io/badge/LLM-589cf4)
 - [2025/09] **[Mask-GCG: Are All Tokens in Adversarial Suffixes Necessary for Jailbreak Attacks?](https://arxiv.org/abs/2509.06350)** ![LLM](https://img.shields.io/badge/LLM-589cf4)
 - [2025/09] **[Between a Rock and a Hard Place: Exploiting Ethical Reasoning to Jailbreak LLMs](https://arxiv.org/abs/2509.05367)** ![LLM](https://img.shields.io/badge/LLM-589cf4)
 - [2025/09] **[Behind the Mask: Benchmarking Camouflaged Jailbreaks in Large Language Models](https://arxiv.org/abs/2509.05471)** ![LLM](https://img.shields.io/badge/LLM-589cf4)


### PR DESCRIPTION
Adds SABER: Uncovering Vulnerabilities in Safety Alignment via Cross-Layer Residual Connection to the jailbreak reading list. SABER is a white-box jailbreak method; the entry uses the paper's September 2025 arXiv date and follows the existing LLM-tag format.